### PR TITLE
Get-SCOMManagementPacks 4.4

### DIFF
--- a/Get-SCOMManagementPacks.ps1
+++ b/Get-SCOMManagementPacks.ps1
@@ -90,6 +90,7 @@
         Georgi Ivanov
         Damian Flynn
         Gabriel Taylor
+        Lynne Taggart
 
     Related URLs:
         Original Git Repo: https://github.com/slavizh/Get-SCOMManagementPacks
@@ -99,14 +100,11 @@
         Technet Gallery post (v3.0.1): https://gallery.technet.microsoft.com/scriptcenter/All-Management-Packs-for-37d37902
         Stefan Stranger's blog post which started it all: http://blogs.technet.com/b/stefan_stranger/archive/2013/03/13/finding-management-packs-from-microsoft-download-website-using-powershell.aspx
 
-    Current Version: 4.3
-    - Version 4.3 Changes
-        - Edits: Gabriel Taylor
-        - Date: 21 February 2017
-        - Removed [parameter(Mandatory=$false)] statements (that's a bad practice, my bad)
-        - Updated MP Wiki URL to HTTPS
-        - Updated Switch parameter validation
-        - Updated formatting
+    Current Version: 4.4
+    - Version 4.4 Changes
+        - Edits: Lynne Taggart
+        - Date: 11 December 2017
+        - Fixed bug that didn't allowed pulling Published date and MP version due to MSFT download page layout changes
 #>
 
 [CmdletBinding(DefaultParameterSetName="AgeMonths")]
@@ -253,12 +251,12 @@ function Get-MSDownloadVersionDetails
         {
             $Status = "Success"
 
-            if ($HTTPData -match 'Version:</span></div><p>(.+?)</p></div>')
+            if ($HTTPData -match 'Version:\s*</div><p>(.+?)</p></div>')
             {
                 $MPVersion = $matches[1].Replace("?","").TrimEnd()
             }
 
-            if ($HTTPData -match 'Date Published:</span></div><p>(.+?)</p></div>')
+            if ($HTTPData -match 'Date Published:\s*</div><p>(.+?)</p></div>')
             {
                 $MPPublishDate = $matches[1].Replace("/","-").TrimEnd()
             }

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ This is an updated version of the script started by Stanislav Zhelyazkov which i
 and download all official SCOM management packs based on their presence on the Microsoft SCOM
 Management Pack Wiki.
 
-Version 4.3 changes by Gabriel Taylor:
+Version 4.4 changes by Lynne Taggart:
 
-* Removed [parameter(Mandatory=$false)] statements (that's a bad practice, my bad)
-* Updated MP Wiki URL to HTTPS
-* Updated Switch parameter validation
-* Updated formatting
+* Fixed bug that didn't allowed pulling Published date and MP version due to MSFT download page layout
+ changes
 
 ## Description
 
@@ -242,3 +240,14 @@ Version History:
 * Version 4.2 Changes
   * Fixed bug in ReDownloadMissingFiles behavior
   * Fixed issue with HTTPS download pages
+ 
+* Version 4.3 Changes:
+  * Removed [parameter(Mandatory=$false)] statements (that's a bad practice, my bad)
+  * Updated MP Wiki URL to HTTPS
+  * Updated Switch parameter validation
+  * Updated formatting
+
+Version 4.4 Changes:
+
+* Fixed bug that didn't allowed pulling Published date and MP version due to MSFT download page layout
+ changes


### PR DESCRIPTION
- Fixed bug that didn't allowed pulling Published date and MP version due to MSFT download page layout
 changes